### PR TITLE
ci: trigger release workflow on release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
 name: Release library
 
 on:
-  push:
-    tags:
-      - 'v*'
+  release:
+    types: [created]
+  workflow_dispatch:
 
 jobs:
   build-release:


### PR DESCRIPTION
Tag-push triggers have not been firing for this repo since v2.0.2 (June 2026) — the npm publish never ran and the broken 2.0.1 stayed on the registry. Follow the org convention (`release: types: [created]`, see external-dns-porkbun-webhook) and add `workflow_dispatch` as a manual fallback.