### PR TITLE
Fix: sort descending flag was inverted

### DIFF
--- a/docs/typedoc.json
+++ b/docs/typedoc.json
@@ -17,7 +17,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 30,
 					"character": 16,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L30"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L30"
 				}
 			],
 			"signatures": [
@@ -38,7 +38,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 30,
 							"character": 16,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L30"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L30"
 						}
 					],
 					"parameters": [
@@ -78,7 +78,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 1564,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L1564"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L1564"
 				}
 			],
 			"signatures": [
@@ -130,7 +130,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 1564,
 							"character": 21,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L1564"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L1564"
 						}
 					],
 					"parameters": [
@@ -191,7 +191,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 556,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L556"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L556"
 				}
 			],
 			"signatures": [
@@ -243,7 +243,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 556,
 							"character": 29,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L556"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L556"
 						}
 					],
 					"parameters": [
@@ -285,7 +285,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 1084,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L1084"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L1084"
 				}
 			],
 			"signatures": [
@@ -337,7 +337,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 1084,
 							"character": 24,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L1084"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L1084"
 						}
 					],
 					"parameters": [
@@ -401,7 +401,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 906,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L906"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L906"
 				}
 			],
 			"signatures": [
@@ -453,7 +453,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 906,
 							"character": 27,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L906"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L906"
 						}
 					],
 					"parameters": [
@@ -503,7 +503,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 994,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L994"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L994"
 				}
 			],
 			"signatures": [
@@ -555,7 +555,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 994,
 							"character": 29,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L994"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L994"
 						}
 					],
 					"parameters": [
@@ -603,7 +603,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 1107,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L1107"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L1107"
 				}
 			],
 			"signatures": [
@@ -655,7 +655,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 1107,
 							"character": 26,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L1107"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L1107"
 						}
 					],
 					"parameters": [
@@ -719,7 +719,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 1130,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L1130"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L1130"
 				}
 			],
 			"signatures": [
@@ -771,7 +771,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 1130,
 							"character": 27,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L1130"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L1130"
 						}
 					],
 					"parameters": [
@@ -838,7 +838,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 1153,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L1153"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L1153"
 				}
 			],
 			"signatures": [
@@ -890,7 +890,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 1153,
 							"character": 25,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L1153"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L1153"
 						}
 					],
 					"parameters": [
@@ -954,7 +954,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 1173,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L1173"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L1173"
 				}
 			],
 			"signatures": [
@@ -1022,7 +1022,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 1173,
 							"character": 30,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L1173"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L1173"
 						}
 					],
 					"parameters": [
@@ -1110,7 +1110,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 396,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L396"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L396"
 				}
 			],
 			"signatures": [
@@ -1162,7 +1162,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 396,
 							"character": 25,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L396"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L396"
 						}
 					],
 					"parameters": [
@@ -1225,7 +1225,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 1061,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L1061"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L1061"
 				}
 			],
 			"signatures": [
@@ -1277,7 +1277,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 1061,
 							"character": 24,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L1061"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L1061"
 						}
 					],
 					"parameters": [
@@ -1344,7 +1344,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 889,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L889"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L889"
 				}
 			],
 			"signatures": [
@@ -1396,7 +1396,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 889,
 							"character": 26,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L889"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L889"
 						}
 					],
 					"parameters": [
@@ -1484,7 +1484,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 1197,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L1197"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L1197"
 				}
 			],
 			"signatures": [
@@ -1536,7 +1536,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 1197,
 							"character": 27,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L1197"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L1197"
 						}
 					],
 					"parameters": [
@@ -1619,7 +1619,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 923,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L923"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L923"
 				}
 			],
 			"signatures": [
@@ -1671,7 +1671,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 923,
 							"character": 28,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L923"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L923"
 						}
 					],
 					"parameters": [
@@ -1721,7 +1721,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 940,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L940"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L940"
 				}
 			],
 			"signatures": [
@@ -1773,7 +1773,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 940,
 							"character": 28,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L940"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L940"
 						}
 					],
 					"parameters": [
@@ -1821,7 +1821,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 964,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L964"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L964"
 				}
 			],
 			"signatures": [
@@ -1873,7 +1873,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 964,
 							"character": 25,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L964"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L964"
 						}
 					],
 					"parameters": [
@@ -1963,7 +1963,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 1013,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L1013"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L1013"
 				}
 			],
 			"signatures": [
@@ -2015,7 +2015,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 1013,
 							"character": 29,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L1013"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L1013"
 						}
 					],
 					"parameters": [
@@ -2078,7 +2078,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 796,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L796"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L796"
 				}
 			],
 			"signatures": [
@@ -2130,7 +2130,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 796,
 							"character": 23,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L796"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L796"
 						}
 					],
 					"parameters": [
@@ -2177,7 +2177,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 467,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L467"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L467"
 				}
 			],
 			"signatures": [
@@ -2229,7 +2229,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 467,
 							"character": 28,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L467"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L467"
 						}
 					],
 					"parameters": [
@@ -2271,7 +2271,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 441,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L441"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L441"
 				}
 			],
 			"signatures": [
@@ -2323,7 +2323,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 441,
 							"character": 28,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L441"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L441"
 						}
 					],
 					"parameters": [
@@ -2365,7 +2365,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 226,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L226"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L226"
 				}
 			],
 			"signatures": [
@@ -2417,7 +2417,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 226,
 							"character": 25,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L226"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L226"
 						}
 					],
 					"parameters": [
@@ -2459,7 +2459,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 590,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L590"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L590"
 				}
 			],
 			"signatures": [
@@ -2511,7 +2511,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 590,
 							"character": 20,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L590"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L590"
 						}
 					],
 					"parameters": [
@@ -2553,7 +2553,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 316,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L316"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L316"
 				}
 			],
 			"signatures": [
@@ -2605,7 +2605,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 316,
 							"character": 24,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L316"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L316"
 						}
 					],
 					"parameters": [
@@ -2666,7 +2666,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 1443,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L1443"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L1443"
 				}
 			],
 			"signatures": [
@@ -2718,7 +2718,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 1443,
 							"character": 31,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L1443"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L1443"
 						}
 					],
 					"parameters": [
@@ -2779,7 +2779,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 1421,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L1421"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L1421"
 				}
 			],
 			"signatures": [
@@ -2831,7 +2831,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 1421,
 							"character": 27,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L1421"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L1421"
 						}
 					],
 					"parameters": [
@@ -2911,7 +2911,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 1369,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L1369"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L1369"
 				}
 			],
 			"signatures": [
@@ -2963,7 +2963,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 1369,
 							"character": 30,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L1369"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L1369"
 						}
 					],
 					"parameters": [
@@ -3033,7 +3033,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 1403,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L1403"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L1403"
 				}
 			],
 			"signatures": [
@@ -3085,7 +3085,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 1403,
 							"character": 32,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L1403"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L1403"
 						}
 					],
 					"parameters": [
@@ -3127,7 +3127,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 356,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L356"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L356"
 				}
 			],
 			"signatures": [
@@ -3179,7 +3179,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 356,
 							"character": 24,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L356"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L356"
 						}
 					],
 					"parameters": [
@@ -3240,7 +3240,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 573,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L573"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L573"
 				}
 			],
 			"signatures": [
@@ -3292,7 +3292,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 573,
 							"character": 21,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L573"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L573"
 						}
 					],
 					"parameters": [
@@ -3334,7 +3334,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 707,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L707"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L707"
 				}
 			],
 			"signatures": [
@@ -3386,7 +3386,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 707,
 							"character": 26,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L707"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L707"
 						}
 					],
 					"parameters": [
@@ -3447,7 +3447,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 728,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L728"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L728"
 				}
 			],
 			"signatures": [
@@ -3499,7 +3499,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 728,
 							"character": 29,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L728"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L728"
 						}
 					],
 					"parameters": [
@@ -3560,7 +3560,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 680,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L680"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L680"
 				}
 			],
 			"signatures": [
@@ -3612,7 +3612,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 680,
 							"character": 28,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L680"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L680"
 						}
 					],
 					"parameters": [
@@ -3673,7 +3673,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 492,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L492"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L492"
 				}
 			],
 			"signatures": [
@@ -3725,7 +3725,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 492,
 							"character": 30,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L492"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L492"
 						}
 					],
 					"parameters": [
@@ -3767,7 +3767,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 1607,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L1607"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L1607"
 				}
 			],
 			"signatures": [
@@ -3810,7 +3810,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 1607,
 							"character": 23,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L1607"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L1607"
 						}
 					],
 					"parameters": [
@@ -3852,7 +3852,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 86,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L86"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L86"
 				}
 			],
 			"signatures": [
@@ -3904,7 +3904,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 86,
 							"character": 22,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L86"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L86"
 						}
 					],
 					"parameters": [
@@ -3946,7 +3946,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 1526,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L1526"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L1526"
 				}
 			],
 			"signatures": [
@@ -3998,7 +3998,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 1526,
 							"character": 40,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L1526"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L1526"
 						}
 					],
 					"parameters": [
@@ -4059,7 +4059,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 208,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L208"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L208"
 				}
 			],
 			"signatures": [
@@ -4111,7 +4111,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 208,
 							"character": 25,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L208"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L208"
 						}
 					],
 					"parameters": [
@@ -4153,7 +4153,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 1041,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L1041"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L1041"
 				}
 			],
 			"signatures": [
@@ -4205,7 +4205,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 1041,
 							"character": 24,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L1041"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L1041"
 						}
 					],
 					"parameters": [
@@ -4272,7 +4272,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 762,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L762"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L762"
 				}
 			],
 			"signatures": [
@@ -4324,7 +4324,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 762,
 							"character": 19,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L762"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L762"
 						}
 					],
 					"parameters": [
@@ -4371,7 +4371,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 1318,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L1318"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L1318"
 				}
 			],
 			"signatures": [
@@ -4423,7 +4423,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 1318,
 							"character": 22,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L1318"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L1318"
 						}
 					],
 					"type": {
@@ -4444,7 +4444,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 779,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L779"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L779"
 				}
 			],
 			"signatures": [
@@ -4496,7 +4496,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 779,
 							"character": 19,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L779"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L779"
 						}
 					],
 					"parameters": [
@@ -4543,7 +4543,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 841,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L841"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L841"
 				}
 			],
 			"signatures": [
@@ -4595,7 +4595,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 841,
 							"character": 19,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L841"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L841"
 						}
 					],
 					"parameters": [
@@ -4637,7 +4637,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 1304,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L1304"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L1304"
 				}
 			],
 			"signatures": [
@@ -4689,7 +4689,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 1304,
 							"character": 19,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L1304"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L1304"
 						}
 					],
 					"type": {
@@ -4710,7 +4710,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 1259,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L1259"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L1259"
 				}
 			],
 			"signatures": [
@@ -4762,7 +4762,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 1259,
 							"character": 29,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L1259"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L1259"
 						}
 					],
 					"parameters": [
@@ -4816,7 +4816,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 1221,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L1221"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L1221"
 				}
 			],
 			"signatures": [
@@ -4868,7 +4868,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 1221,
 							"character": 26,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L1221"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L1221"
 						}
 					],
 					"parameters": [
@@ -4913,7 +4913,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 1278,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L1278"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L1278"
 				}
 			],
 			"signatures": [
@@ -4965,7 +4965,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 1278,
 							"character": 27,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L1278"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L1278"
 						}
 					],
 					"parameters": [
@@ -5028,7 +5028,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 1240,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L1240"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L1240"
 				}
 			],
 			"signatures": [
@@ -5080,7 +5080,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 1240,
 							"character": 28,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L1240"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L1240"
 						}
 					],
 					"parameters": [
@@ -5125,7 +5125,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 294,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L294"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L294"
 				}
 			],
 			"signatures": [
@@ -5177,7 +5177,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 294,
 							"character": 19,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L294"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L294"
 						}
 					],
 					"parameters": [
@@ -5258,7 +5258,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 535,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L535"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L535"
 				}
 			],
 			"signatures": [
@@ -5310,7 +5310,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 535,
 							"character": 28,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L535"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L535"
 						}
 					],
 					"parameters": [
@@ -5352,7 +5352,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 249,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L249"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L249"
 				}
 			],
 			"signatures": [
@@ -5404,7 +5404,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 249,
 							"character": 26,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L249"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L249"
 						}
 					],
 					"parameters": [
@@ -5446,7 +5446,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 630,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L630"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L630"
 				}
 			],
 			"signatures": [
@@ -5498,7 +5498,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 630,
 							"character": 21,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L630"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L630"
 						}
 					],
 					"parameters": [
@@ -5561,7 +5561,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 663,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L663"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L663"
 				}
 			],
 			"signatures": [
@@ -5613,7 +5613,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 663,
 							"character": 28,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L663"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L663"
 						}
 					],
 					"type": {
@@ -5634,7 +5634,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 417,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L417"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L417"
 				}
 			],
 			"signatures": [
@@ -5686,7 +5686,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 417,
 							"character": 23,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L417"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L417"
 						}
 					],
 					"parameters": [
@@ -5766,7 +5766,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 608,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L608"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L608"
 				}
 			],
 			"signatures": [
@@ -5818,7 +5818,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 608,
 							"character": 21,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L608"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L608"
 						}
 					],
 					"parameters": [
@@ -5881,7 +5881,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 376,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L376"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L376"
 				}
 			],
 			"signatures": [
@@ -5933,7 +5933,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 376,
 							"character": 21,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L376"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L376"
 						}
 					],
 					"parameters": [
@@ -5997,7 +5997,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 648,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L648"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L648"
 				}
 			],
 			"signatures": [
@@ -6049,7 +6049,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 648,
 							"character": 20,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L648"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L648"
 						}
 					],
 					"parameters": [
@@ -6091,7 +6091,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 336,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L336"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L336"
 				}
 			],
 			"signatures": [
@@ -6143,7 +6143,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 336,
 							"character": 26,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L336"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L336"
 						}
 					],
 					"parameters": [
@@ -6204,7 +6204,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 111,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L111"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L111"
 				}
 			],
 			"signatures": [
@@ -6256,7 +6256,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 111,
 							"character": 25,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L111"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L111"
 						}
 					],
 					"parameters": [
@@ -6336,7 +6336,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 171,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L171"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L171"
 				}
 			],
 			"signatures": [
@@ -6388,7 +6388,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 171,
 							"character": 30,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L171"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L171"
 						}
 					],
 					"parameters": [
@@ -6449,7 +6449,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 150,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L150"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L150"
 				}
 			],
 			"signatures": [
@@ -6501,7 +6501,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 150,
 							"character": 31,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L150"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L150"
 						}
 					],
 					"parameters": [
@@ -6562,7 +6562,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 745,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L745"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L745"
 				}
 			],
 			"signatures": [
@@ -6614,7 +6614,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 745,
 							"character": 19,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L745"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L745"
 						}
 					],
 					"parameters": [
@@ -6661,7 +6661,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 855,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L855"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L855"
 				}
 			],
 			"signatures": [
@@ -6713,7 +6713,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 855,
 							"character": 26,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L855"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L855"
 						}
 					],
 					"parameters": [
@@ -6760,7 +6760,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 815,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L815"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L815"
 				}
 			],
 			"signatures": [
@@ -6812,7 +6812,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 815,
 							"character": 25,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L815"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L815"
 						}
 					],
 					"parameters": [
@@ -6854,7 +6854,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 1336,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L1336"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L1336"
 				}
 			],
 			"signatures": [
@@ -6906,7 +6906,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 1336,
 							"character": 26,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L1336"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L1336"
 						}
 					],
 					"parameters": [
@@ -6980,7 +6980,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 71,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L71"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L71"
 				}
 			],
 			"signatures": [
@@ -7041,7 +7041,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 71,
 							"character": 22,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L71"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L71"
 						}
 					],
 					"parameters": [
@@ -7083,7 +7083,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 517,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L517"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L517"
 				}
 			],
 			"signatures": [
@@ -7135,7 +7135,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 517,
 							"character": 24,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L517"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L517"
 						}
 					],
 					"parameters": [
@@ -7177,7 +7177,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 55,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L55"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L55"
 				}
 			],
 			"signatures": [
@@ -7229,7 +7229,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 55,
 							"character": 24,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L55"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L55"
 						}
 					],
 					"parameters": [
@@ -7291,7 +7291,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 270,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L270"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L270"
 				}
 			],
 			"signatures": [
@@ -7343,7 +7343,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 270,
 							"character": 20,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L270"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L270"
 						}
 					],
 					"parameters": [
@@ -7406,7 +7406,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 192,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L192"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L192"
 				}
 			],
 			"signatures": [
@@ -7458,7 +7458,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 192,
 							"character": 25,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L192"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L192"
 						}
 					],
 					"parameters": [
@@ -7500,7 +7500,7 @@
 					"fileName": "extended-grammar.ts",
 					"line": 1585,
 					"character": 13,
-					"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L1585"
+					"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L1585"
 				}
 			],
 			"signatures": [
@@ -7552,7 +7552,7 @@
 							"fileName": "extended-grammar.ts",
 							"line": 1585,
 							"character": 20,
-							"url": "https://github.com/konnektr-io/jexl-extended/blob/d1883e4d0d4b610ff158f663f96fb5711c7653d0/src/extended-grammar.ts#L1585"
+							"url": "https://github.com/konnektr-io/jexl-extended/blob/5427708bdc944125aeddd349e85c395d2b329684/src/extended-grammar.ts#L1585"
 						}
 					],
 					"type": {

--- a/src/extended-grammar.ts
+++ b/src/extended-grammar.ts
@@ -972,8 +972,8 @@ export const arraySort = (
   const compareFunction = (a: unknown, b: unknown) => {
     const aValue = expr.evalSync(a);
     const bValue = expr.evalSync(b);
-    if (aValue < bValue) return descending ? -1 : 1;
-    if (aValue > bValue) return descending ? 1 : -1;
+    if (aValue < bValue) return descending ? 1 : -1;
+    if (aValue > bValue) return descending ? -1 : 1;
     return 0;
   };
   return [...input].sort(compareFunction);

--- a/test/jexl-extended.vitest.test.ts
+++ b/test/jexl-extended.vitest.test.ts
@@ -237,6 +237,11 @@ test("arrays", () => {
     jexl.evalSync(
       '[{name:"tek",age:32}, {name:"bar",age:34}, {name:"baz",age:33}, {name:"foo",age:35}]|sort("age",true)|mapField("name")',
     ),
+  ).toEqual(["foo", "bar", "baz", "tek"]);
+  expect(
+    jexl.evalSync(
+      '[{name:"tek",age:32}, {name:"bar",age:34}, {name:"baz",age:33}, {name:"foo",age:35}]|sort("age",false)|mapField("name")',
+    ),
   ).toEqual(["tek", "baz", "bar", "foo"]);
   expect(jexl.evalSync('["foo"]|append(["tek","baz","bar"]|sort)')).toEqual([
     "foo",


### PR DESCRIPTION
Closes #10

## Problem
`sort(field, true)` returned **ascending** order and `sort(field, false)` returned **descending** — inverted relative to the C# flow engine (`JexlNet`) and the Python port (`pyjexl-extended`), where `true` = descending.

## Fix
- `src/extended-grammar.ts` — corrected the `arraySort` compare function so `descending=true` sorts descending and `false` ascending.
- `test/jexl-extended.vitest.test.ts:238` — updated the assertion to expect the real descending order and added an explicit ascending (`false`) case.

## Verification
- `pnpm test` → 41/41 passed (was 41/41 with a wrong-but-passing assertion; now actually enforced).
- Manual: `sort("age", true)` → `["foo","bar","baz","tek"]` (descending), `sort("age", false)` → `["tek","baz","bar","foo"]` (ascending).