### PR TITLE
fix: ship @types/jexl as a runtime dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     }
   },
   "dependencies": {
+    "@types/jexl": "^2.3.4",
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",
     "jexl": "^2.3.0",
@@ -81,7 +82,6 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
-    "@types/jexl": "^2.3.4",
     "@types/node": "^25.6.0",
     "@typescript-eslint/eslint-plugin": "^8.59.0",
     "@typescript-eslint/parser": "^8.59.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@types/jexl':
+        specifier: ^2.3.4
+        version: 2.3.4
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
@@ -30,9 +33,6 @@ importers:
       '@eslint/js':
         specifier: ^9.39.4
         version: 9.39.4
-      '@types/jexl':
-        specifier: ^2.3.4
-        version: 2.3.4
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0


### PR DESCRIPTION
## Problem

`jexl@2.3.0` ships **no bundled types**, and `@types/jexl` was only a `devDependency`. Because `JexlExtended extends Jexl` re-exports the base-class types through `dist/index.d.ts` (`import { Jexl } from 'jexl'`), consumers of the published package lose typing on the inherited API — `evalSync`, `compile`, `eval`, `createExpression` all degrade to implicit `any`.

**Repro against published `2.0.1`** (strict consumer project, no `@types/jexl` of its own):

```
consumer.ts(8,19): error TS2339: Property 'compile' does not exist on type 'JexlExtended'.
consumer.ts(12,30): error TS2339: Property 'evalSync' does not exist on type 'JexlExtended'.
node_modules/jexl-extended/dist/index.d.ts(1,22): error TS7016: Could not find a declaration file for module 'jexl'.
```

## Fix

Move `@types/jexl` from `devDependencies` → `dependencies` so it is installed transitively with the package. Also moved in `pnpm-lock.yaml` (importer section).

## Verification

- `pnpm pack` → installed the tarball into a **fresh** consumer project (npm, no explicit `@types/jexl`) → `node_modules/@types/jexl` present.
- Strict `tsc` over `evalSync`/`compile`/default-instance usage: **passes cleanly**.
- Same file against published `2.0.1`: fails with TS7016/TS2339 (above).
- Repo build (`npm run build`) + tests (41/41) green.

## Notes

- Separate from #10 (sort flag) as requested — no overlap with that branch's changes.
- Next publish (v2.0.4) will carry the fix; no other release infra changes needed.